### PR TITLE
Added ability to configure classpath file

### DIFF
--- a/lib/collector.js
+++ b/lib/collector.js
@@ -81,7 +81,8 @@ function readClassPath() {
     return Promise.resolve([]);
   }
 
-  return Promise.all([ readFileAsync(`${paths[0]}/.classpath`), implicitLibs() ])
+  return Promise.all([ readFileAsync(`${paths[0]}/${atom.config.get('java-classpath-registry.classpathFile')}`),
+      implicitLibs() ])
     .then(([ classpath, libs ]) => classpath.toString('utf8').split(delimiter).concat(libs))
     .catch(handleMissingClasspath)
     .then(filterFalsyArray)

--- a/package.json
+++ b/package.json
@@ -52,6 +52,12 @@
       "default": 30,
       "minimum": 0,
       "description": "The time (in days) too keep cache of .class and .jar files."
+    },
+    "classpathFile": {
+      "name": "Classpath File",
+      "type": "string",
+      "default": ".classpath",
+      "description": "The name of the classpath file to use."
     }
   }
 }


### PR DESCRIPTION
I'm running into conflicts where .classpath wants to be used by both this package and Eclipse and their expected formats are not compatible. This will allow me to have two different files co-exist side by side.