### PR TITLE
Improve implicit libs detection

### DIFF
--- a/lib/collector.js
+++ b/lib/collector.js
@@ -29,8 +29,8 @@ function hashFileContent(filename) {
 function implicitLibs() {
   return new Promise((resolve, reject) => {
     exec('java -verbose -help', (err, stdout, stderr) => { // Cannot promisify due to multiple args in callback
-      // Output sample: `[Loaded java.lang.Shutdown from /Library/Java/JavaVirtualMachines/jdk1.8.0_92.jdk/Contents/Home/jre/lib/rt.jar]`
-      const match = stdout.match(/\[Loaded (?:[^\s]+) from (.*)\/.*\.jar\]/);
+      // Output sample: `[Opened /Library/Java/JavaVirtualMachines/jdk1.8.0_92.jdk/Contents/Home/jre/lib/rt.jar]`
+      const match = stdout.match(/\[Opened (.*)[\\\/]rt\.jar\]/);
       return (err || !match) ?
         reject(err || 'Failed to find implicit libs') :
         resolve(match[1]);


### PR DESCRIPTION
I was having problems with this package on Windows: the libs specified in .classpath would load correctly, but not the implicit libs.

To solve this, I updated the implicitLibs() function in collector.js to:
* detect the phrase "Opened ..." instead of "Loaded ... from ..."
* support backslashes as well as forward slashes for Windows compatibility
* only load Java's rt.jar

Now everything works on both Windows and Linux.